### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - LC_ALL=en_US.UTF-8
       - KONG_DATABASE=postgres
       - KONG_PG_HOST=kong-database
-      - KONG_PG_USER = kong
+      - KONG_PG_USER=kong
       - KONG_PG_PASSWORD=kong
       - KONG_CASSANDRA_CONTACT_POINTS=kong-database
       - KONG_PROXY_ACCESS_LOG=/dev/stdout


### PR DESCRIPTION
Fix for: 
ERROR: environment variable name 'KONG_PG_USER ' may not contain whitespace.