### PR TITLE
patch: network error in docker-compose >=2.4.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,6 @@ volumes:
   db-data-kong-postgres:
 
 networks:
-    default:
-        external:
-            name: kong-net
-
+  default:
+    name: kong-net
+    external: true


### PR DESCRIPTION
Removes WARN[0000] network default: network.external.name is deprecated in favor of network.name 

patch: network error in docker-compose >=2.4.1